### PR TITLE
fix skip_init import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ protobuf>=3.19.5,<3.20.1
 transformers>=4.26.1
 icetk
 cpm_kernels
+torch>=1.10


### PR DESCRIPTION
`skip_init` is only available for torch >= 1.10. Add this to `requirements.txt`.