### PR TITLE
修复api服务启动错误

### DIFF
--- a/api.py
+++ b/api.py
@@ -28,8 +28,8 @@ async def create_item(request: Request):
 
 
 if __name__ == '__main__':
-    uvicorn.run('API:app', host='0.0.0.0', port=8000, workers=1)
+    uvicorn.run('api:app', host='0.0.0.0', port=8000, workers=1)
 
 tokenizer = AutoTokenizer.from_pretrained("THUDM/chatglm-6b", trust_remote_code=True)
-model = AutoModel.from_pretrained("THUDM/chatglm_6b", trust_remote_code=True).half().cuda()
+model = AutoModel.from_pretrained("THUDM/chatglm-6b", trust_remote_code=True).half().cuda()
 model.eval()


### PR DESCRIPTION
第31行【API】->【api】会因为大小写原因找不到API
第34行的下划线【chatglm_6b】->【chatglm-6b】会导致模型加载错误
#218 [BUG/Help] <python3 api.py报错> 
#219 未补充的模型下划线问题