### PR TITLE
chore(cli_demo): strip the query input for `stop` or `clear` command

### DIFF
--- a/cli_demo.py
+++ b/cli_demo.py
@@ -31,9 +31,9 @@ def main():
     print("欢迎使用 ChatGLM-6B 模型，输入内容即可进行对话，clear 清空对话历史，stop 终止程序")
     while True:
         query = input("\n用户：")
-        if query == "stop":
+        if query.strip() == "stop":
             break
-        if query == "clear":
+        if query.strip() == "clear":
             history = []
             os.system(clear_command)
             print("欢迎使用 ChatGLM-6B 模型，输入内容即可进行对话，clear 清空对话历史，stop 终止程序")


### PR DESCRIPTION
Remove the query space to determine whether it is a stop command or a clear command.

如果不小心前后多打了空格，例如 `stop ` `  stop  ` 等，则无法退出，简单修改了一下。