### PR TITLE
fix finetune pad bug and add sat readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ ChatGLM-6B 使用了和 ChatGPT 相似的技术，针对中文问答和对话进
 
 ## 友情链接
 以下是部分基于本仓库开发的开源项目：
+* [SwissArmyTransformer](https://github.com/THUDM/SwissArmyTransformer): 一个Transformer统一编程框架，ChatGLM-6B已经在SAT中进行实现并可以进行P-tuning微调。
 * [ChatGLM-MNN](https://github.com/wangzhaode/ChatGLM-MNN): 一个基于 MNN 的 ChatGLM-6B C++ 推理实现，支持根据显存大小自动分配计算任务给 GPU 和 CPU
 * [ChatGLM-Tuning](https://github.com/mymusise/ChatGLM-Tuning): 基于 LoRA 对 ChatGLM-6B 进行微调。类似的项目还包括 [Humanable ChatGLM/GPT Fine-tuning | ChatGLM 微调](https://github.com/hscspring/hcgf)
 * [langchain-ChatGLM](https://github.com/imClumsyPanda/langchain-ChatGLM)：基于本地知识的 ChatGLM 应用，基于LangChain

--- a/ptuning/main.py
+++ b/ptuning/main.py
@@ -187,6 +187,8 @@ def main():
                 pad_len = max_seq_length - len(input_ids)
                 input_ids = input_ids + [tokenizer.pad_token_id] * pad_len
                 labels = labels + [tokenizer.pad_token_id] * pad_len
+                if data_args.ignore_pad_token_for_loss:
+                    labels = [(l if l != tokenizer.pad_token_id else -100) for l in labels]
 
                 model_inputs["input_ids"].append(input_ids)
                 model_inputs["labels"].append(labels)


### PR DESCRIPTION
Hi, I found that the training labels has pad bug and I fixed it. Moreover, I add a link in readme of [SAT-chatglm](https://github.com/THUDM/SwissArmyTransformer/tree/main/examples/chatglm).