### PR TITLE
add api_stream,return the response of the stream_chat by asynchronously

### DIFF
--- a/api_stream.py
+++ b/api_stream.py
@@ -1,0 +1,98 @@
+from fastapi import FastAPI, Request
+from transformers import AutoTokenizer, AutoModel
+import uvicorn
+import json
+import datetime
+import torch
+import threading
+
+DEVICE = "cuda"
+DEVICE_ID = "0"
+CUDA_DEVICE = f"{DEVICE}:{DEVICE_ID}" if DEVICE_ID else DEVICE
+
+stream_buffer = {}
+
+
+def torch_gc():
+    if torch.cuda.is_available():
+        with torch.cuda.device(CUDA_DEVICE):
+            torch.cuda.empty_cache()
+            torch.cuda.ipc_collect()
+
+
+app = FastAPI()
+
+
+def stream_item(prompt, history, max_length, top_p, temperature):
+    global model, tokenizer
+    global stream_buffer
+    for response, history in model.stream_chat(tokenizer, prompt, history=history, max_length=max_length, top_p=top_p,
+                                               temperature=temperature):
+        query, response = history[-1]
+        now = datetime.datetime.now()
+        stream_buffer[prompt] = {
+            "response": response, "stop": False, "time": now}
+    stream_buffer[prompt]["stop"] = True
+    torch_gc()
+
+
+def removeTimeoutBuffer():
+    for key in stream_buffer.copy():
+        if stream_buffer[key]["stop"]:
+            diff = datetime.datetime.now() - stream_buffer[key]["time"]
+            seconds = diff.total_seconds()
+            print(key + ": 已存在" + str(seconds) + "秒")
+            if seconds > 120:
+                del stream_buffer[key]
+                print(key + "：已被删除")
+
+
+@app.post("/stream")
+async def create_item(request: Request):
+    # 删除过期的buffer
+    removeTimeoutBuffer()
+    # 全局变量buffer
+    global stream_buffer
+    # 获取入参
+    json_post_raw = await request.json()
+    json_post = json.dumps(json_post_raw)
+    json_post_list = json.loads(json_post)
+    prompt = json_post_list.get('prompt')
+    history = json_post_list.get('history')
+    max_length = json_post_list.get('max_length')
+    top_p = json_post_list.get('top_p')
+    temperature = json_post_list.get('temperature')
+    # 判断是否已在生成，只有首次才调stream_chat
+    now = datetime.datetime.now()
+    if stream_buffer.get(prompt) is None:
+        stream_buffer[prompt] = {"response": "", "stop": False, "time": now}
+        # 在线程中调用stream_chat
+        sub_thread = threading.Thread(target=stream_item, args=(prompt, history, max_length if max_length else 2048,
+                                                                top_p if top_p else 0.7, temperature if temperature else 0.95))
+        sub_thread.start()
+    # 异步返回response
+    time = now.strftime("%Y-%m-%d %H:%M:%S")
+    response = stream_buffer[prompt]["response"]
+    # 如果stream_chat调用完成，给返回加一个停止词[stop]
+    if stream_buffer[prompt]["stop"]:
+        response = response + '[stop]'
+    answer = {
+        "response": response,
+        "history": history,
+        "status": 200,
+        "time": time
+    }
+    log = "[" + time + "] " + '", prompt:"' + \
+        prompt + '", response:"' + repr(response) + '"'
+    print(log)
+
+    return answer
+
+
+if __name__ == '__main__':
+    tokenizer = AutoTokenizer.from_pretrained(
+        "THUDM/chatglm-6b", trust_remote_code=True)
+    model = AutoModel.from_pretrained(
+        "THUDM/chatglm-6b", trust_remote_code=True).half().cuda()
+    model.eval()
+    uvicorn.run(app, host='0.0.0.0', port=8000, workers=1)


### PR DESCRIPTION
增加了api_stream，实现了将stream_chat同步调用以异步方式提供给http请求。stream_chat的结果存放在定期清理的缓存中。调用方式如下：
curl -X POST "http://127.0.0.1:8000\stream" \
     -H 'Content-Type: application/json' \
     -d '{"prompt": "你好", "history": []}'