### PR TITLE
 [Document] 更新Mac部署说明

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -20,7 +20,7 @@
 
 对 ChatGLM-6B 进行微调的开源项目：
 * [InstructGLM](https://github.com/yanqiangmiffy/InstructGLM)：基于ChatGLM-6B进行指令学习，汇总开源中英文指令数据，基于Lora进行指令数据微调，开放了Alpaca、Belle微调后的Lora权重，修复web_demo重复问题
-* [ChatGLM-Efficient-Tuning](https://github.com/hiyouga/ChatGLM-Efficient-Tuning)：基于ChatGLM-6B模型进行定制化微调，汇总10余种指令数据集和3种微调方案，实现了4/8比特量化和模型权重融合，提供微调模型快速部署方法。
+* [ChatGLM-Efficient-Tuning](https://github.com/hiyouga/ChatGLM-Efficient-Tuning)：实现了ChatGLM-6B模型的监督微调和完整RLHF训练，汇总10余种指令数据集和3种微调方案，实现了4/8比特量化和模型权重融合，提供微调模型快速部署方法。
 * [ChatGLM-Finetuning](https://github.com/liucongg/ChatGLM-Finetuning)：基于ChatGLM-6B模型，进行下游具体任务微调，涉及Freeze、Lora、P-tuning等，并进行实验效果对比。
 * [ChatGLM-Tuning](https://github.com/mymusise/ChatGLM-Tuning): 基于 LoRA 对 ChatGLM-6B 进行微调。类似的项目还包括 [Humanable ChatGLM/GPT Fine-tuning | ChatGLM 微调](https://github.com/hscspring/hcgf)
 

--- a/README_en.md
+++ b/README_en.md
@@ -191,26 +191,21 @@ If your encounter the error `Could not find module 'nvcuda.dll'` or `RuntimeErro
 
 ### CPU Deployment on Mac
 
-The default Mac enviroment does not support Openmp. One may encounter such warning/errors when execute the `AutoModel.from_pretrained(...)` command:
+The default Mac enviroment does not support Openmp. One may encounter such warning/errors when execute the `AutoModel.from_pretrained(...)` command `clang: error: unsupported option '-fopenmp'`.
 
-```sh
-clang: error: unsupported option '-fopenmp'
-clang: error: unsupported option '-fopenmp'
-```
+Take the quantified int4 version [chatglm-6b-int4](https://huggingface.co/THUDM/chatglm-6b-int4) for example, two extra steps are needed.
 
-Take the quantified int4 version [chatglm-6b-int4](https://huggingface.co/THUDM/chatglm-6b-int4) for example, the following extra steps are needed:
-
-#### Install `libomp`
+#### STEP 1: Install `libomp`
 
 ```bash
-# STEP 1: install libopenmp, check `https://mac.r-project.org/openmp/` for details
-## Assumption: `gcc(clang) >= 14.x`, read the R-Poject before run the code:
+# STEP 1: install libopenmp, check `https://mac.r-project.org/openmp/` for details.
+# Assumption: `gcc(clang) >= 14.x`, read the R-Poject before run the code:
 curl -O https://mac.r-project.org/openmp/openmp-14.0.6-darwin20-Release.tar.gz
 sudo tar fvxz openmp-14.0.6-darwin20-Release.tar.gz -C /
 ```
 Four files (`/usr/local/lib/libomp.dylib`, `/usr/local/include/ompt.h`, `/usr/local/include/omp.h`, `/usr/local/include/omp-tools.h`) are installed accordingly.
 
-#### Configure `gcc` with `-fopenmp`
+#### STEP 2: Configure `gcc` with `-fopenmp`
 
 Next, modify the [quantization.py](https://huggingface.co/THUDM/chatglm-6b-int4/blob/main/quantization.py) file of the `chatglm-6b-int4` project. In the file, change the `gcc -O3 -fPIC -pthread -fopenmp -std=c99` configuration to `gcc -O3 -fPIC -Xclang -fopenmp -pthread  -lomp -std=c99` (check the corresponding python code [HERE](https://huggingface.co/THUDM/chatglm-6b-int4/blob/63d66b0572d11cedd5574b38da720299599539b3/quantization.py#L168)), i.e.:
 
@@ -219,22 +214,9 @@ Next, modify the [quantization.py](https://huggingface.co/THUDM/chatglm-6b-int4/
 compile_command = "gcc -O3 -fPIC -Xclang -fopenmp -pthread  -lomp -std=c99 {} -shared -o {}".format(source_code, kernel_file)
 ```
 
-For production code, one could use `platform` library to make it neater:
+> Notice: `platform.uname()[0] == 'Darwin'` could be used to determine the OS type and further polish the python script.
 
-```python
-## import platform just after `import os`
-import platform
-## ...
-## change the corresponding lines to:
-if platform.uname()[0] == 'Darwin':
-    compile_command = "gcc -O3 -fPIC -Xclang -fopenmp -pthread  -lomp -std=c99 -o {}".format(
-    source_code, kernel_file)
-else:
-    compile_command = "gcc -O3 -fPIC -pthread -fopenmp -std=c99 {} -shared -o {}".format(
-    source_code, kernel_file)
-```
-
-> Notice: If you have run the `ChatGLM` project and failed, you may want to clean the cache of Huggingface before your next try, i.e. `rm -rf ${HOME}/.cache/huggingface/modules/transformers_modules/chatglm-6b-int4`. Since `rm` is used, please MAKE SURE that the command deletes the right files.
+> Notice: If you have executed the `ChatGLM` project and failed, you may want to clean the cache of Huggingface before your next try, i.e. `rm -rf ${HOME}/.cache/huggingface/modules/transformers_modules/chatglm-6b-int4`. Since `rm` is used, please MAKE SURE that the command deletes the right files.
 
 ### GPU Inference on Mac
 For Macs (and MacBooks) with Apple Silicon, it is possible to use the MPS backend to run ChatGLM-6B on the GPU. First, you need to refer to Apple's [official instructions](https://developer.apple.com/metal/pytorch) to install PyTorch-Nightly.

--- a/README_en.md
+++ b/README_en.md
@@ -188,6 +188,58 @@ model = AutoModel.from_pretrained("THUDM/chatglm-6b-int4", trust_remote_code=Tru
 
 If your encounter the error `Could not find module 'nvcuda.dll'` or `RuntimeError: Unknown platform: darwin`(MacOS), please [load the model locally](README_en.md#load-the-model-locally). 
 
+
+### CPU Deployment on Mac
+
+The default Mac enviroment does not support Openmp. One may encounter such warning/errors when execute the `AutoModel.from_pretrained(...)` command:
+
+```sh
+clang: error: unsupported option '-fopenmp'
+clang: error: unsupported option '-fopenmp'
+```
+
+Take the quantified int4 version [chatglm-6b-int4](https://huggingface.co/THUDM/chatglm-6b-int4) for example, the following extra steps are needed:
+
+1. Install `libomp`;
+2. Configure `gcc`.
+
+```bash
+# STEP 1: install libopenmp, check `https://mac.r-project.org/openmp/` for details
+## Assumption: `gcc -v >= 14.x`, read the R-Poject before run the code:
+curl -O https://mac.r-project.org/openmp/openmp-14.0.6-darwin20-Release.tar.gz
+sudo tar fvxz openmp-14.0.6-darwin20-Release.tar.gz -C /
+## Four files are installed:
+#   usr/local/lib/libomp.dylib
+#   usr/local/include/ompt.h
+#   usr/local/include/omp.h
+#   usr/local/include/omp-tools.h
+```
+
+For `chatglm-6b-int4`, modify the [quantization.py](https://huggingface.co/THUDM/chatglm-6b-int4/blob/main/quantization.py)file. In the file, change the `gcc -O3 -fPIC -pthread -fopenmp -std=c99` configuration to `gcc -O3 -fPIC -Xclang -fopenmp -pthread  -lomp -std=c99`，[corresponding python code](https://huggingface.co/THUDM/chatglm-6b-int4/blob/63d66b0572d11cedd5574b38da720299599539b3/quantization.py#L168), i.e.:
+
+```python
+# STEP
+## Change the line contains `gcc -O3 -fPIC -pthread -fopenmp -std=c99` to:
+compile_command = "gcc -O3 -fPIC -Xclang -fopenmp -pthread  -lomp -std=c99 {} -shared -o {}".format(source_code, kernel_file)
+```
+
+For production code, one could use `platform` library to make it neater:
+
+```python
+## import platform just after `import os`
+import platform
+## ...
+## change the corresponding lines to:
+if platform.uname()[0] == 'Darwin':
+    compile_command = "gcc -O3 -fPIC -Xclang -fopenmp -pthread  -lomp -std=c99-o {}".format(
+    source_code, kernel_file)
+else:
+    compile_command = "gcc -O3 -fPIC -pthread -fopenmp -std=c99 {} -shared -o {}".format(
+    source_code, kernel_file)
+```
+
+> Notice: If you have run the `chatglm` project and failed, you may want to clean the cache of Huggingface before your next try, i.e. `rm -rf ${HOME}/.cache/huggingface/modules/transformers_modules/chatglm-6b-int4`. Since `rm` is used, please MAKE SURE that the command deletes the right files.
+
 ### GPU Inference on Mac
 For Macs (and MacBooks) with Apple Silicon, it is possible to use the MPS backend to run ChatGLM-6B on the GPU. First, you need to refer to Apple's [official instructions](https://developer.apple.com/metal/pytorch) to install PyTorch-Nightly.
 
@@ -195,7 +247,16 @@ Currently you must [load the model locally](README_en.md#load-the-model-locally)
 ```python
 model = AutoModel.from_pretrained("your local path", trust_remote_code=True).half().to('mps')
 ```
+
+For Mac users with Mac >= 13.3, one may encounter errors related to `half()` method. Use `float()` instead:
+
+```python
+model = AutoModel.from_pretrained("your local path", trust_remote_code=True).float().to('mps')
+```
+
 Then you can use GPU-accelerated model inference on Mac.
+
+> Notice: there is no promblem to run the non-quantified version of ChatGLM with MPS. One could check [this issue](https://github.com/THUDM/ChatGLM-6B/issues/462) to run the quantified version with MPS as the backend (and get `ERRORS`). Unzip/unpack [kernel](https://huggingface.co/THUDM/chatglm-6b/blob/658202d88ac4bb782b99e99ac3adff58b4d0b813/quantization.py#L27) as an `ELF` file shows its backend is `cuda`.
 
 ### Multi-GPU Deployment
 If you have multiple GPUs, but the memory size of each GPU is not sufficient to accommodate the entire model, you can split the model across multiple GPUs. 

--- a/README_en.md
+++ b/README_en.md
@@ -200,26 +200,22 @@ clang: error: unsupported option '-fopenmp'
 
 Take the quantified int4 version [chatglm-6b-int4](https://huggingface.co/THUDM/chatglm-6b-int4) for example, the following extra steps are needed:
 
-1. Install `libomp`;
-2. Configure `gcc`.
+#### Install `libomp`
 
 ```bash
 # STEP 1: install libopenmp, check `https://mac.r-project.org/openmp/` for details
-## Assumption: `gcc -v >= 14.x`, read the R-Poject before run the code:
+## Assumption: `gcc(clang) >= 14.x`, read the R-Poject before run the code:
 curl -O https://mac.r-project.org/openmp/openmp-14.0.6-darwin20-Release.tar.gz
 sudo tar fvxz openmp-14.0.6-darwin20-Release.tar.gz -C /
-## Four files are installed:
-#   usr/local/lib/libomp.dylib
-#   usr/local/include/ompt.h
-#   usr/local/include/omp.h
-#   usr/local/include/omp-tools.h
 ```
+Four files (`/usr/local/lib/libomp.dylib`, `/usr/local/include/ompt.h`, `/usr/local/include/omp.h`, `/usr/local/include/omp-tools.h`) are installed accordingly.
 
-For `chatglm-6b-int4`, modify the [quantization.py](https://huggingface.co/THUDM/chatglm-6b-int4/blob/main/quantization.py)file. In the file, change the `gcc -O3 -fPIC -pthread -fopenmp -std=c99` configuration to `gcc -O3 -fPIC -Xclang -fopenmp -pthread  -lomp -std=c99`，[corresponding python code](https://huggingface.co/THUDM/chatglm-6b-int4/blob/63d66b0572d11cedd5574b38da720299599539b3/quantization.py#L168), i.e.:
+#### Configure `gcc` with `-fopenmp`
+
+Next, modify the [quantization.py](https://huggingface.co/THUDM/chatglm-6b-int4/blob/main/quantization.py) file of the `chatglm-6b-int4` project. In the file, change the `gcc -O3 -fPIC -pthread -fopenmp -std=c99` configuration to `gcc -O3 -fPIC -Xclang -fopenmp -pthread  -lomp -std=c99` (check the corresponding python code [HERE](https://huggingface.co/THUDM/chatglm-6b-int4/blob/63d66b0572d11cedd5574b38da720299599539b3/quantization.py#L168)), i.e.:
 
 ```python
-# STEP
-## Change the line contains `gcc -O3 -fPIC -pthread -fopenmp -std=c99` to:
+# STEP 2: Change the line contains `gcc -O3 -fPIC -pthread -fopenmp -std=c99` to:
 compile_command = "gcc -O3 -fPIC -Xclang -fopenmp -pthread  -lomp -std=c99 {} -shared -o {}".format(source_code, kernel_file)
 ```
 
@@ -231,14 +227,14 @@ import platform
 ## ...
 ## change the corresponding lines to:
 if platform.uname()[0] == 'Darwin':
-    compile_command = "gcc -O3 -fPIC -Xclang -fopenmp -pthread  -lomp -std=c99-o {}".format(
+    compile_command = "gcc -O3 -fPIC -Xclang -fopenmp -pthread  -lomp -std=c99 -o {}".format(
     source_code, kernel_file)
 else:
     compile_command = "gcc -O3 -fPIC -pthread -fopenmp -std=c99 {} -shared -o {}".format(
     source_code, kernel_file)
 ```
 
-> Notice: If you have run the `chatglm` project and failed, you may want to clean the cache of Huggingface before your next try, i.e. `rm -rf ${HOME}/.cache/huggingface/modules/transformers_modules/chatglm-6b-int4`. Since `rm` is used, please MAKE SURE that the command deletes the right files.
+> Notice: If you have run the `ChatGLM` project and failed, you may want to clean the cache of Huggingface before your next try, i.e. `rm -rf ${HOME}/.cache/huggingface/modules/transformers_modules/chatglm-6b-int4`. Since `rm` is used, please MAKE SURE that the command deletes the right files.
 
 ### GPU Inference on Mac
 For Macs (and MacBooks) with Apple Silicon, it is possible to use the MPS backend to run ChatGLM-6B on the GPU. First, you need to refer to Apple's [official instructions](https://developer.apple.com/metal/pytorch) to install PyTorch-Nightly.
@@ -248,7 +244,7 @@ Currently you must [load the model locally](README_en.md#load-the-model-locally)
 model = AutoModel.from_pretrained("your local path", trust_remote_code=True).half().to('mps')
 ```
 
-For Mac users with Mac >= 13.3, one may encounter errors related to `half()` method. Use `float()` instead:
+For Mac users with Mac OS >= 13.3, one may encounter errors related to the `half()` method. Use the `float()` method instead:
 
 ```python
 model = AutoModel.from_pretrained("your local path", trust_remote_code=True).float().to('mps')
@@ -256,7 +252,7 @@ model = AutoModel.from_pretrained("your local path", trust_remote_code=True).flo
 
 Then you can use GPU-accelerated model inference on Mac.
 
-> Notice: there is no promblem to run the non-quantified version of ChatGLM with MPS. One could check [this issue](https://github.com/THUDM/ChatGLM-6B/issues/462) to run the quantified version with MPS as the backend (and get `ERRORS`). Unzip/unpack [kernel](https://huggingface.co/THUDM/chatglm-6b/blob/658202d88ac4bb782b99e99ac3adff58b4d0b813/quantization.py#L27) as an `ELF` file shows its backend is `cuda`.
+> Notice: there is no promblem to run the non-quantified version of ChatGLM with MPS. One could check [this issue](https://github.com/THUDM/ChatGLM-6B/issues/462) to run the quantified version with MPS as the backend (and get `ERRORS`). Unpacking [kernel](https://huggingface.co/THUDM/chatglm-6b/blob/658202d88ac4bb782b99e99ac3adff58b4d0b813/quantization.py#L27) as an `ELF` file shows its backend is `cuda`, which fails on MPS currently (`torch 2.1.0.dev20230502`).
 
 ### Multi-GPU Deployment
 If you have multiple GPUs, but the memory size of each GPU is not sufficient to accommodate the entire model, you can split the model across multiple GPUs. 


### PR DESCRIPTION
# 更新Mac部署说明

- Type:  Document
- FILES: README.md; README_en.md
- Keywords: OPENMP; MPS

## 具体更新内容

以[chatglm-6b-int4](https://huggingface.co/THUDM/chatglm-6b-int4)量化模型为例，做如下配置：

- 安装libomp的步骤;
- 对量化后模型等配置gcc编译项，并启用OMP加速推理；
- 量化后模型启用MPS（然后失败）的解释。

Mac 启用OMP涉及`https://huggingface.co/THUDM/chatglm-6b-int4`中`quantization.py`的修改由于需要手动安装一些依赖，不单独commit，而直接描述在了说明中。


## 已经验证环境：

Mac M1 Ultra 128GB
Mac OS: 13.3.1
GCC: Apple clang version 14.0.3 (clang-1403.0.22.14.1)
conda 23.3.1
torch (two versions, with MPS) 
- '2.0.0';
- '2.1.0.dev20230502'
