### PR TITLE
fix input unicodedecodererror

### DIFF
--- a/cli_demo.py
+++ b/cli_demo.py
@@ -2,6 +2,7 @@ import os
 import platform
 import signal
 from transformers import AutoTokenizer, AutoModel
+import readline
 
 tokenizer = AutoTokenizer.from_pretrained("THUDM/chatglm-6b", trust_remote_code=True)
 model = AutoModel.from_pretrained("THUDM/chatglm-6b", trust_remote_code=True).half().cuda()


### PR DESCRIPTION
修复client输入中文退格时，input函数会抛UnicodeDecoderError异常，导致对话中断退出。
相关issue：#493 