### PR TITLE
enhance: 优化API接口代码以及Swagger界面显示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.vscode
+ptuning/data
+ptuning/output
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/api.py
+++ b/api.py
@@ -1,40 +1,49 @@
+import json
+import datetime
+import torch
+import uvicorn
+from typing import List
 from fastapi import FastAPI, Request
 from transformers import AutoTokenizer, AutoModel
-import uvicorn, json, datetime
-import torch
-
-DEVICE = "cuda"
-DEVICE_ID = "0"
-CUDA_DEVICE = f"{DEVICE}:{DEVICE_ID}" if DEVICE_ID else DEVICE
+from pydantic import BaseModel
+from utils import load_model_on_gpus
 
 
-def torch_gc():
+devices_list = [
+    'cuda:0',
+    'cuda:1'
+]
+
+
+def _torch_gc():
     if torch.cuda.is_available():
-        with torch.cuda.device(CUDA_DEVICE):
-            torch.cuda.empty_cache()
-            torch.cuda.ipc_collect()
+        for item in devices_list:
+            with torch.cuda.device(item):
+                torch.cuda.empty_cache()
+                torch.cuda.ipc_collect()
+
+
+class Question(BaseModel):
+    prompt: str
+    history: List[str] = []
+    max_length: int = 2048
+    top_p: float = 0.7
+    temperature: float = 0.95
 
 
 app = FastAPI()
 
 
-@app.post("/")
-async def create_item(request: Request):
-    global model, tokenizer
-    json_post_raw = await request.json()
-    json_post = json.dumps(json_post_raw)
-    json_post_list = json.loads(json_post)
-    prompt = json_post_list.get('prompt')
-    history = json_post_list.get('history')
-    max_length = json_post_list.get('max_length')
-    top_p = json_post_list.get('top_p')
-    temperature = json_post_list.get('temperature')
-    response, history = model.chat(tokenizer,
-                                   prompt,
-                                   history=history,
-                                   max_length=max_length if max_length else 2048,
-                                   top_p=top_p if top_p else 0.7,
-                                   temperature=temperature if temperature else 0.95)
+@app.post('/chat/')
+async def chat(question: Question):
+    response, history = model.chat(
+        tokenizer,
+        question.prompt,
+        history=question.history,
+        max_length=question.max_length,
+        top_p=question.top_p,
+        temperature=question.temperature
+    )
     now = datetime.datetime.now()
     time = now.strftime("%Y-%m-%d %H:%M:%S")
     answer = {
@@ -43,14 +52,15 @@ async def create_item(request: Request):
         "status": 200,
         "time": time
     }
-    log = "[" + time + "] " + '", prompt:"' + prompt + '", response:"' + repr(response) + '"'
-    print(log)
-    torch_gc()
+    _torch_gc()
     return answer
 
 
-if __name__ == '__main__':
-    tokenizer = AutoTokenizer.from_pretrained("THUDM/chatglm-6b", trust_remote_code=True)
-    model = AutoModel.from_pretrained("THUDM/chatglm-6b", trust_remote_code=True).half().cuda()
+if __name__ == "__main__":
+    tokenizer = AutoTokenizer.from_pretrained(
+        "THUDM/chatglm-6b", trust_remote_code=True
+    )
+    model = load_model_on_gpus("THUDM/chatglm-6b", num_gpus=2)
+    # model = AutoModel.from_pretrained("THUDM/chatglm-6b", trust_remote_code=True).half().cuda()
     model.eval()
-    uvicorn.run(app, host='0.0.0.0', port=8000, workers=1)
+    uvicorn.run(app, host="127.0.0.1", port=11001, workers=1)

--- a/cli_demo_gpus.py
+++ b/cli_demo_gpus.py
@@ -1,0 +1,59 @@
+import os
+import platform
+import signal
+from transformers import AutoTokenizer, AutoModel
+from utils import load_model_on_gpus
+
+tokenizer = AutoTokenizer.from_pretrained("THUDM/chatglm-6b", trust_remote_code=True)
+model = load_model_on_gpus("THUDM/chatglm-6b", num_gpus=2)
+# model = AutoModel.from_pretrained("THUDM/chatglm-6b", trust_remote_code=True).half().cuda()
+model = model.eval()
+
+os_name = platform.system()
+clear_command = 'cls' if os_name == 'Windows' else 'clear'
+stop_stream = False
+
+
+def build_prompt(history):
+    prompt = "欢迎使用 ChatGLM-6B 模型，输入内容即可进行对话，clear 清空对话历史，stop 终止程序"
+    for query, response in history:
+        prompt += f"\n\n用户：{query}"
+        prompt += f"\n\nChatGLM-6B：{response}"
+    return prompt
+
+
+def signal_handler(signal, frame):
+    global stop_stream
+    stop_stream = True
+
+
+def main():
+    history = []
+    global stop_stream
+    print("欢迎使用 ChatGLM-6B 模型，输入内容即可进行对话，clear 清空对话历史，stop 终止程序")
+    while True:
+        query = input("\n用户：")
+        if query.strip() == "stop":
+            break
+        if query.strip() == "clear":
+            history = []
+            os.system(clear_command)
+            print("欢迎使用 ChatGLM-6B 模型，输入内容即可进行对话，clear 清空对话历史，stop 终止程序")
+            continue
+        count = 0
+        for response, history in model.stream_chat(tokenizer, query, history=history):
+            if stop_stream:
+                stop_stream = False
+                break
+            else:
+                count += 1
+                if count % 8 == 0:
+                    os.system(clear_command)
+                    print(build_prompt(history), flush=True)
+                    signal.signal(signal.SIGINT, signal_handler)
+        os.system(clear_command)
+        print(build_prompt(history), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/ptuning/evaluate.sh
+++ b/ptuning/evaluate.sh
@@ -2,10 +2,10 @@ PRE_SEQ_LEN=128
 CHECKPOINT=adgen-chatglm-6b-pt-128-2e-2
 STEP=3000
 
-CUDA_VISIBLE_DEVICES=0 python3 main.py \
+CUDA_VISIBLE_DEVICES=0,1,2,3 python3 main.py \
     --do_predict \
-    --validation_file AdvertiseGen/dev.json \
-    --test_file AdvertiseGen/dev.json \
+    --validation_file data/AdvertiseGen/dev.json \
+    --test_file data/AdvertiseGen/dev.json \
     --overwrite_cache \
     --prompt_column content \
     --response_column summary \

--- a/ptuning/train.sh
+++ b/ptuning/train.sh
@@ -1,10 +1,12 @@
 PRE_SEQ_LEN=128
 LR=2e-2
 
-CUDA_VISIBLE_DEVICES=0 python3 main.py \
+export 'PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:32'
+
+CUDA_VISIBLE_DEVICES=0,1,2,3 python3 main.py \
     --do_train \
-    --train_file AdvertiseGen/train.json \
-    --validation_file AdvertiseGen/dev.json \
+    --train_file data/AdvertiseGen/train.json \
+    --validation_file data/AdvertiseGen/dev.json \
     --prompt_column content \
     --response_column summary \
     --overwrite_cache \

--- a/ptuning/web_demo.py
+++ b/ptuning/web_demo.py
@@ -119,8 +119,7 @@ with gr.Blocks() as demo:
 def main():
     global model, tokenizer
 
-    parser = HfArgumentParser((
-        ModelArguments))
+    parser = HfArgumentParser((ModelArguments))
     if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
         # If we pass only one argument to the script and it's the path to a json file,
         # let's parse it to get our arguments.
@@ -158,7 +157,7 @@ def main():
         model.transformer.prefix_encoder.float().cuda()
     
     model = model.eval()
-    demo.queue().launch(share=False, inbrowser=True)
+    demo.queue().launch(share=False, inbrowser=True, server_port=11001)
 
 
 

--- a/ptuning/web_demo.sh
+++ b/ptuning/web_demo.sh
@@ -1,7 +1,8 @@
 PRE_SEQ_LEN=128
 
-CUDA_VISIBLE_DEVICES=0 python3 web_demo.py \
+CUDA_VISIBLE_DEVICES=0,1 python3 web_demo.py \
     --model_name_or_path THUDM/chatglm-6b \
     --ptuning_checkpoint output/adgen-chatglm-6b-pt-128-2e-2/checkpoint-3000 \
-    --pre_seq_len $PRE_SEQ_LEN
+    --pre_seq_len $PRE_SEQ_LEN \
+    --quantization_bit 4
 


### PR DESCRIPTION
enhance: 优化API接口代码以及Swagger界面显示

原本的代码是直接在 `create_item` 方法里读取 request body

接口需要传入的各个参数在Swagger界面都没有展示，不够直观，代码冗余度比较高

第24-26行重复进行了无意义的json序列化和反序列化

本 pr 对API接口进行了重写，接口方法的代码缩减到了38行，swagger更加直观

效果如下

![image](https://github.com/THUDM/ChatGLM-6B/assets/11494144/a0607feb-88a0-481f-8dac-74ccabad7d59)
