### PR TITLE
update ptuning readme for pip install

### DIFF
--- a/ptuning/README.md
+++ b/ptuning/README.md
@@ -8,7 +8,7 @@
 ## 软件依赖
 运行微调需要4.27.1版本的`transformers`。除 ChatGLM-6B 的依赖之外，还需要安装以下依赖
 ```
-pip install rouge_chinese nltk jieba datasets
+pip install rouge_chinese nltk jieba datasets cpm_kernels sentencepiece
 ```
 ## 使用方法
 

--- a/ptuning/README_en.md
+++ b/ptuning/README_en.md
@@ -6,7 +6,7 @@ The following uses the [ADGEN](https://aclanthology.org/D19-1321.pdf) (advertisi
 ## Software dependencies
 Running p-tuning requires version 4.27.1 of `transformers`. In addition to the dependencies of ChatGLM-6B, the following dependencies are required
 ```
-pip install rouge_chinese nltk jieba datasets
+pip install rouge_chinese nltk jieba datasets cpm_kernels sentencepiece
 ```
 ## Instructions
 


### PR DESCRIPTION
Missing these installs when i tried to train ptuning.